### PR TITLE
Ignore new NSObject properties introduced with iOS 8

### DIFF
--- a/NSObject+NSCoding.m
+++ b/NSObject+NSCoding.m
@@ -39,8 +39,7 @@
     objc_property_t property = pt[i];
     NSString *name = [NSString stringWithUTF8String:property_getName(property)];
 
-    // Ignore properties indrocuded with iOS 8
-    if ([@[@"description", @"debugDescription", @"superclass"] containsObject:name]) {
+    if (![self shouldEncodePropertyName:name]) {
         continue;
     }
 
@@ -114,8 +113,7 @@
     objc_property_t property = pt[i];
     NSString *name = [NSString stringWithUTF8String:property_getName(property)];
 
-    // Ignore properties indrocuded with iOS 8
-    if ([@[@"description", @"debugDescription", @"superclass"] containsObject:name]) {
+    if (![self shouldEncodePropertyName:name]) {
         continue;
     }
 
@@ -191,6 +189,15 @@
 }
 
 #pragma mark - private
+
+- (BOOL)shouldEncodePropertyName:(NSString *)name {
+    // Ignore properties indrocuded with iOS 8
+    if ([@[@"description", @"debugDescription", @"superclass"] containsObject:name]) {
+        return NO;
+    }
+    
+    return YES;
+}
 
 + (NSString *)getMethodReturnType:(Method)mt
 {


### PR DESCRIPTION
iOS 8 introduced some new properties on NSObject which cause AutoNSCoding to crash on encode/decode.

See http://www.redwindsoftware.com/blog/post/2014/08/20/NSObject-has-some-new-properties-in-iOS-8.aspx for further information.

This fix will just ignore the new properties.
